### PR TITLE
Updating url-parse to 1.4.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7958,7 +7958,7 @@
       }
     },
     "url-parse": {
-      "version": "1.2.0",
+      "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.2.0.tgz",
       "integrity": "sha512-DT1XbYAfmQP65M/mE6OALxmXzZ/z1+e5zk2TcSKe/KiYbNGZxgtttzC0mR/sjopbpOXcbniq7eIKmocJnUWlEw==",
       "requires": {


### PR DESCRIPTION
Updating url-parse to 1.4.3 to address security vulnerability and close #67