### PR TITLE
Upgrading js-yaml, fixes two vulnerable patches

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5322,8 +5322,8 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
       "integrity": "sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=",
       "dev": true,
       "requires": {
@@ -8592,7 +8592,7 @@
         "coa": "1.0.4",
         "colors": "1.1.2",
         "csso": "2.3.2",
-        "js-yaml": "3.7.0",
+        "js-yaml": "3.13.1",
         "mkdirp": "0.5.1",
         "sax": "1.2.4",
         "whet.extend": "0.9.9"


### PR DESCRIPTION
Fix for issue #91 which highlighted two vulnerabilities. This addresses both and gets to the latest version.