### PR TITLE
Load jquery script over https

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -12,7 +12,7 @@
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp"
         crossorigin="anonymous">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css">
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.7/jquery.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7/jquery.min.js"></script>
 </head>
 
 <body class="body">


### PR DESCRIPTION
![Screen Shot 2019-10-01 at 12 44 19 PM](https://user-images.githubusercontent.com/3642545/65982387-3b4a9580-e449-11e9-9542-af97674ffd74.png)
 The jquery script loaded in `index.html` should be loaded over HTTPS to avoid a Mixed Content error.