### PR TITLE
 this pull request resolves isssue #107  "Add sticky footer across all pages with three content areas "

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -2,6 +2,7 @@ body {
   padding-bottom: 70px; /* equal to footer height */
 }
 
+
 .panel {
     background: #e5e0d3 !important;
     border-bottom: none;

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -1,3 +1,7 @@
+body {
+  padding-bottom: 70px; /* equal to footer height */
+}
+
 .panel {
     background: #e5e0d3 !important;
     border-bottom: none;

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -9,6 +9,7 @@ import NewProject from './pages/NewProject';
 import LogIn from './pages/LogIn';
 import './App.css';
 import Nav from './components/Nav';
+import Footer from './components/Footer/Footer';
 
 const App = () => (
   <Router>
@@ -20,9 +21,10 @@ const App = () => (
         <Route path="/saved" component={SavedProjects} />
         <Route path="/new" component={NewProject} />
         {/* <Route path="/edit/:id" component={NewProject} /> */}
-        <Route path="/allprojects" component={AllProjects} />>
+        <Route path="/allprojects" component={AllProjects} />
         <Route path="/" component={LogIn} />
       </Switch>
+      <Footer />
     </Container>
   </Router>
 );

--- a/client/src/components/Footer/Footer.css
+++ b/client/src/components/Footer/Footer.css
@@ -1,0 +1,37 @@
+.footer {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  background: #f8f8f8;
+  padding: 10px 20px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border-top: 1px solid #ddd;
+  z-index: 999;
+}
+
+.footer-left,
+.footer-middle,
+.footer-right {
+  flex: 1;
+}
+
+.footer-middle {
+  text-align: center;
+}
+
+.footer-right {
+  text-align: right;
+}
+
+.footer-icon {
+  margin: 0 10px;
+  font-size: 20px;
+  color: #333;
+}
+
+.footer-icon:hover {
+  color: #007bff;
+}

--- a/client/src/components/Footer/Footer.js
+++ b/client/src/components/Footer/Footer.js
@@ -1,0 +1,38 @@
+import React from "react";
+import "./Footer.css";   // create this file also
+
+function Footer() {
+  return (
+    <footer className="footer">
+      <div className="footer-left">
+        {/* left column empty */}
+      </div>
+
+      <div className="footer-middle">
+        <a
+          href="https://twitter.com"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="footer-icon"
+        >
+          <i className="fab fa-twitter"></i>
+        </a>
+
+        <a
+          href="https://facebook.com"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="footer-icon"
+        >
+          <i className="fab fa-facebook"></i>
+        </a>
+      </div>
+
+      <div className="footer-right">
+        {/* reserved for future widgets */}
+      </div>
+    </footer>
+  );
+}
+
+export default Footer;


### PR DESCRIPTION
->Add Sticky Footer With Three Content Sections
This pull request adds a global sticky footer that appears across all pages of the application. The footer is divided into three columns:
Left column: intentionally left blank for future content
Middle column: contains Twitter and Facebook icons with external links
Right column: reserved for upcoming widgets referenced in other open issues

->Changes Included
Added a new Footer.js component under client/src/components/
Added Footer.css for layout and styling
Updated App.js to render the footer on all pages
Added bottom padding in global styles to prevent the footer from overlapping page content